### PR TITLE
Feature multi staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osp_decidim
+FROM rg.fr-par.scw.cloud/decidim/osp-decidim-base:latest
 
 ENV USER_ID=1000 \
     GROUP_ID=2000 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM ruby:2.6.0
-LABEL maintainer="hola@decidim.org"
+FROM osp_decidim
 
 ENV USER_ID=1000 \
     GROUP_ID=2000 \
@@ -9,37 +8,19 @@ ENV USER_ID=1000 \
     BUNDLE_RETRY=5 \
     APP_HOME=/usr/src/app/ \
     PATH=${APP_HOME}/bin:${PATH} \
-    SECRET_KEY_BASE=dummy_key_base
+    SECRET_KEY_BASE=dummy_key_base \
+    GEM_HOME="/usr/local/bundle" \
+    PATH=$GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
-RUN apt-get update -qq \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-      apt-transport-https \
-      build-essential \
-      graphviz \
-      imagemagick \
-      libicu-dev \
-      libpq-dev \
-    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /root/yarn-pubkey.gpg && apt-key add /root/yarn-pubkey.gpg \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
-      nodejs \
-      yarn \
-    && apt-get clean \
-    && rm -rf /var/cache/apt/archives/* \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && truncate -s 0 /var/log/*log \
-    && addgroup --gid ${GROUP_ID} decidim \
-    && useradd -m -s /bin/bash -g ${GROUP_ID} -u ${USER_ID} decidim \
-    && chown -R decidim: /usr/local/bundle
+USER root
 
-RUN mkdir ${APP_HOME}
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
+
 WORKDIR ${APP_HOME}
 
-RUN chown -R decidim: ${APP_HOME}
-USER decidim
-
 COPY --chown=decidim:decidim Gemfile Gemfile.lock ${APP_HOME}
+
+USER decidim
 
 RUN gem uninstall bundler \
     && gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)" \
@@ -47,9 +28,7 @@ RUN gem uninstall bundler \
 
 COPY --chown=decidim:decidim . ${APP_HOME}
 
-RUN bundle exec rails assets:precompile
-
-RUN chmod +x ./sidekiq_alive.sh ./sidekiq_quiet.sh ./puma_alive.sh ./docker-entrypoint.sh
+RUN bundle exec rake assets:clobber assets:precompile
 
 EXPOSE 3000
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,29 @@
+FROM ruby:2.6.0
+LABEL maintainer="hola@decidim.org"
+
+ENV USER_ID=1000 \
+    GROUP_ID=2000 \
+    APP_HOME=/usr/src/app/
+
+RUN addgroup --gid ${GROUP_ID} decidim && useradd -m -s /bin/bash -g ${GROUP_ID} -u ${USER_ID} decidim
+RUN mkdir ${APP_HOME}
+
+RUN apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+      apt-transport-https \
+      build-essential \
+      graphviz \
+      imagemagick \
+      libicu-dev \
+      libpq-dev \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /root/yarn-pubkey.gpg && apt-key add /root/yarn-pubkey.gpg \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+      nodejs \
+      yarn \
+    && apt-get clean \
+    && rm -rf /var/cache/apt/archives/* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && truncate -s 0 /var/log/*log
+

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ REGISTRY := rg.fr-par.scw.cloud
 NAMESPACE := decidim
 VERSION := latest
 IMAGE_NAME := osp-decidim
+BUILD_IMAGE_NAME := osp-decidim-base
+BASE_BUILD_TAG := $(REGISTRY)/$(NAMESPACE)/$(BUILD_IMAGE_NAME):$(VERSION)
 TAG := $(REGISTRY)/$(NAMESPACE)/$(IMAGE_NAME):$(VERSION)
 
 login:
 	docker login $(REGISTRY) -u nologin -p $(SCW_SECRET_TOKEN)
 
 build:
-	 docker build .  --compress -t $(TAG)
+	 docker build --compress -t $(BASE_BUILD_TAG) - < Dockerfile.build
+	 docker build . --compress -t $(TAG)
 
 push:
 	docker push $(TAG)

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,16 @@ login:
 	docker login $(REGISTRY) -u nologin -p $(SCW_SECRET_TOKEN)
 
 build:
-	 docker build --compress -t $(BASE_BUILD_TAG) - < Dockerfile.build
 	 docker build . --compress -t $(TAG)
+
+build-base:
+	 docker build --compress -t $(BASE_BUILD_TAG) - < Dockerfile.build
 
 push:
 	docker push $(TAG)
+
+push-base:
+	docker push $(BASE_BUILD_TAG)
 
 release:
 	@make build


### PR DESCRIPTION
### What ? Why ? 

This feature aims to build the docker images using multi staged build. It allows to speed up the container creation. 

### Tasks

- [x] Configure multi staged build
- [x] Add new build file `Dockerfile.build`
- [x] Allow use of `rake` commands in container
- [x] Fixe JS error on `assets:precompilation`
- [x] Move `bundle exec rails assets:precompile` layer to `bundle exec rake assets:clobber assets:precompile`
- [x] Update build image registry
### More information 

Now, images seems to be heavier from `2.01GB`  to `1.03GB` for build image and `2.13GB` for app image.

However, build time seems to be reduced from 11 minutes to 8 minutes. 