### PR TITLE
Fix tmp folder rights

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN gem uninstall bundler \
 
 COPY --chown=decidim:decidim . ${APP_HOME}
 
-RUN bundle exec rake assets:clobber assets:precompile
+RUN bundle exec rake assets:precompile
 
 EXPOSE 3000
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,7 +6,7 @@ ENV USER_ID=1000 \
     APP_HOME=/usr/src/app/
 
 RUN addgroup --gid ${GROUP_ID} decidim && useradd -m -s /bin/bash -g ${GROUP_ID} -u ${USER_ID} decidim
-RUN mkdir ${APP_HOME}
+RUN mkdir ${APP_HOME} && chown -R decidim:decidim ${APP_HOME}
 
 RUN apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
#### What ? Why ? 

Staging deployment is broken because of rights.

#### Related to 
- #65 

#### Tasks
- [x] Change app folder owner to `decidim:decidim`
- [x] Remove unnecessary `assets:clobber` from Dockerfile
 