### PR TITLE
fix syntax error in main_test workflow

### DIFF
--- a/.github/workflows/main_test.yml
+++ b/.github/workflows/main_test.yml
@@ -35,9 +35,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30 # seconds
       - name: Wait on security checks
-          uses: lewagon/wait-on-check-action@master
-          with:
-            ref: ${{ github.event.pull_request.head.sha }} # can be commit SHA or tag too
-            check-name: security_checks # name of the existing check - omit to wait for all checks
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            wait-interval: 30 # seconds
+        uses: lewagon/wait-on-check-action@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # can be commit SHA or tag too
+          check-name: security_checks # name of the existing check - omit to wait for all checks
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30 # seconds


### PR DESCRIPTION
### What? Why?

According to [previous run](https://github.com/OpenSourcePolitics/osp-app-k8s/actions/runs/600048641), the `main_test` workflow seems to have an invalid syntax 