### PR TITLE
Refactor ensure environment

### DIFF
--- a/.github/workflows/main_test.yml
+++ b/.github/workflows/main_test.yml
@@ -35,9 +35,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30 # seconds
       - name: Wait on security checks
-          uses: lewagon/wait-on-check-action@master
-          with:
-            ref: ${{ github.event.pull_request.head.sha }} # can be commit SHA or tag too
-            check-name: security_checks # name of the existing check - omit to wait for all checks
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            wait-interval: 30 # seconds
+        uses: lewagon/wait-on-check-action@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # can be commit SHA or tag too
+          check-name: security_checks # name of the existing check - omit to wait for all checks
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30 # seconds

--- a/config/initializers/01_ensure_environment.rb
+++ b/config/initializers/01_ensure_environment.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
-if Rails.env.production?
+def required_env_vars
   %w(
     DATABASE_HOST
     DATABASE_NAME
     DATABASE_PASSWORD
     DATABASE_PORT
     DATABASE_USERNAME
-    MAPS_API_KEY
     REDIS_URL
     SCALEWAY_BUCKET_NAME
     SCALEWAY_ID
     SCALEWAY_TOKEN
     SECRET_KEY_BASE
-    SENTRY_DSN
     SMTP_ADDRESS
     SMTP_DOMAIN
     SMTP_PASSWORD
@@ -21,9 +19,23 @@ if Rails.env.production?
     RAILS_LOG_TO_STDOUT
     RAILS_SERVE_STATIC_FILES
     APP_NAME
-  ).each do |env_var|
+  )
+end
+
+def optional_env_vars
+  %w(SENTRY_DSN)
+end
+
+if Rails.env.production? && ENV["DISABLE_ENV_CHECKUP"].blank?
+  required_env_vars.each do |env_var|
     next unless !ENV.has_key?(env_var) || ENV[env_var].blank?
 
     raise "Missing environment variable: #{env_var}"
+  end
+
+  optional_env_vars.each do |env_var|
+    next unless !ENV.has_key?(env_var) || ENV[env_var].blank?
+
+    Rails.logger.warn "Missing environment variable: #{env_var}"
   end
 end


### PR DESCRIPTION
#### What ? Why ? 

On staging cluster, application and sidekiq pods are in `CrashLoopBackOff` status. This is due to the missing env variable `SENTRY_DSN`. 

This PR aims to implement a way to bypass the env checking variable and define required and optional env variables.