### PR TITLE
bump mimemagic gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
#### What ? Why ? 

At the moment CI is failing because of `mimemagic` locked version